### PR TITLE
make init errors more obvious

### DIFF
--- a/autoload/chromatica/init.vim
+++ b/autoload/chromatica/init.vim
@@ -42,11 +42,15 @@ function! chromatica#init#_initialize() abort
             runtime! plugin/rplugin.vim
         endif
         call _chromatica()
-    catch
+    catch /^Vim\%((\a\+)\)\=:E117/
         call chromatica#util#print_error(
                     \ 'chromatica.nvim is not registered as Neovim remote plugins.')
         call chromatica#util#print_error(
                     \ 'Please execute :UpdateRemotePlugins command and restart Neovim.')
+        return 1
+    catch
+        call chromatica#util#print_error(
+                    \ 'There was an error starting Chromatica. Please check g:chromatica#libclang_path.')
         return 1
     endtry
 


### PR DESCRIPTION
Hi - thanks for the cool plugin! This solves a problem I ran into setting it up. I initially had `g:chromatica#libclang_path` set incorrectly, but it took me a while to figure that out because the error I was getting told me to `:UpdateRemotePlugins`. I've separated those two into different `catch` blocks here so that hopefully it is more clear to users what the actual problem is.