### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Or manually check out the repo and put the directory to your vim runtime path.
 
 ## Essential Settings
 
-Like many other clang-based plugins, you need to set the path to your libclang.
+Like many other clang-based plugins, a path to your libclang is needed.
+Chromatica will default to `/usr/lib/libclang.so`, but you can specify a
+different one by setting
 
 ```vim
 let g:chromatica#libclang_path='/usr/local/opt/llvm/lib'
@@ -58,6 +60,18 @@ let g:chromatica#libclang_path='/usr/local/opt/llvm/lib'
 
 The path can be set to either the path of the libclang.dylib/libclang.so file,
 or the directory that contains it.
+
+If you want Chromatica to be automatically loaded at startup, you will need to
+set
+
+```vim
+let g:chromatica#enable_at_startup=1
+```
+
+Alternatively, you can manually enable and disable Chromatica by calling,
+respectively, `:ChromaticaStart` and `:ChromaticaStop`.
+
+
 
 ## Compilation Flags
 

--- a/autoload/chromatica/init.vim
+++ b/autoload/chromatica/init.vim
@@ -101,7 +101,7 @@ function! chromatica#init#_variables() abort
     let g:chromatica#_context = {}
     let g:chromatica#_rank = {}
 
-    " User vairables
+    " User variables
     call chromatica#util#set_default(
                 \ 'g:chromatica#libclang_path', '/usr/lib/libclang.so')
     call chromatica#util#set_default(

--- a/doc/chromatica.txt
+++ b/doc/chromatica.txt
@@ -151,20 +151,20 @@ Default: `0`
 
 Chromatica provides these commands.
 
-|ChromaticaEnable|
-|ChromaticaDisable|
+|ChromaticaStart|
+|ChromaticaStop|
 |ChromaticaToggle|
 |ChromaticaShowInfo|
 
 ------------------------------------------------------------------------------
-					*ChromaticaEnable*
-ChromaticaEnable~
+					*ChromaticaStart*
+ChromaticaStart~
 
 Enable chromatica plugin.
 
 ------------------------------------------------------------------------------
-					*ChromaticaDisable*
-ChromaticaDisable~
+					*ChromaticaStop*
+ChromaticaStop~
 
 Disable chromatica plugin.
 

--- a/doc/chromatica.txt
+++ b/doc/chromatica.txt
@@ -71,9 +71,9 @@ g:chromatica#enable_at_startup == `1`, regardless the filetype. To load
 Chromatica only for C-family languages, please refer to the manual of
 your plugin manager.
 
-Default: `1`
+Default: `0`
 >
-	let g:chromatica#enable_at_startup = 1
+	let g:chromatica#enable_at_startup = 0
 <
 ------------------------------------------------------------------------------
 					*g:chromatica#libclang_path*
@@ -84,9 +84,9 @@ set this option when chromatica cannot find libclang, or other version
 of libclang is used. This can be set to either the libclang file (.so/.dylib)
 or the path to the library.
 
-Default: `''`
+Default: `'/usr/lib/libclang.so'`
 >
-	let g:chromatica#libclang_path = ''
+	let g:chromatica#libclang_path = '/usr/lib/libclang.so'
 <
 -------------------------------------------------------------------------------
 					*g:chromatica#global_args*


### PR DESCRIPTION
* According to the documentation, the default value of `chromatica#enable_at_startup` is `1`, but looking at [init.vim](https://github.com/arakashic/chromatica.nvim/blob/master/autoload/chromatica/init.vim#L108), the default is actually `0`.

* Similarly for `chromatica#libclang_path`, the default value in the documentation is `''`, but in the code it is `/usr/lib/libclang.so`. BTW, isn’t that going to break macOS support?

* The documentation mentions `:ChromaticaEnable` and `:ChromaticaDisable` whereas the actual commands are `:ChromaticaStart` and `:ChromaticaStop`.

* Small typo [here](https://github.com/arakashic/chromatica.nvim/blob/master/autoload/chromatica/init.vim#L104): "vairables" -> "variables"

I don’t know whether `:ChromaticaLogInfo`m `:ChromaticaDbgAST`, `g:chromatica#syntax_src_id` and `g:chromatica#enable_debug` should also be mentioned in the documentation (plus, for some of them I do not know what they actually do), so I left them out of this pull request.