### PR TITLE
Fix 'Key not found' exception

### DIFF
--- a/rplugin/python3/chromatica/chromatica.py
+++ b/rplugin/python3/chromatica/chromatica.py
@@ -205,6 +205,8 @@ class Chromatica(logger.LoggingMixin):
         filetype = buffer.options["filetype"]
         if not Chromatica.is_supported_filetype(filetype): return
 
+        if not 'highlight_tick' in buffer.vars: return
+
         if highlight_tick != buffer.vars["highlight_tick"]: return
 
         if filename not in self.ctx: return self.parse(context)


### PR DESCRIPTION
Checks if the key `highlight_tick` is in the dictionary. This prevent
raising an exception in highlight method.

Related to issue #36 