### PR TITLE
Fix `CXX_ACCESS_SPEC_DECL` usage

### DIFF
--- a/rplugin/python3/chromatica/syntax.py
+++ b/rplugin/python3/chromatica/syntax.py
@@ -348,8 +348,12 @@ def _get_keyword_decl_syn(tu, token, cursor):
     if group:
         return group
     else:
-        if cursor.kind != cindex.CursorKind.UNEXPOSED_DECL: return "chromaticaType"
-        else: return None
+        if cursor.kind not in (cindex.CursorKind.UNEXPOSED_DECL, cindex.CursorKind.CXX_ACCESS_SPEC_DECL):
+            return "chromaticaType"
+        elif cursor.kind == cindex.CursorKind.UNEXPOSED_DECL:
+            return None
+        else:
+            return SYNTAX_GROUP.get(cursor.kind)
 
 def _get_keyword_syn(tu, token, cursor):
     """Handles cursor type of keyword tokens. Providing syntax group for most


### PR DESCRIPTION
Before this commit, `CXX_ACCESS_SPEC_DECL` (e.g. `public` in classes)
were always interpeted as `chromaticaType`. Now,
`chromaticaCXXAccessSpecifier` is used instead.