### PR TITLE
Transform relative isystem to absolute paths

### DIFF
--- a/rplugin/python3/chromatica/compile_args_database.py
+++ b/rplugin/python3/chromatica/compile_args_database.py
@@ -112,6 +112,12 @@ class CompileArgsDatabase(object):
                             include_path = os.path.normpath(
                                 os.path.join(cwd, include_path))
                         res.append('-I' + include_path)
+                    if arg.startswith('-isystem'):
+                        include_path = arg[8:]
+                        if not os.path.isabs(include_path):
+                            include_path = os.path.normpath(
+                                os.path.join(cwd, include_path))
+                        res.append('-isystem' + include_path)
                     if _basename in arg:
                         continue;
                     else:


### PR DESCRIPTION
If the `directory` value specified in the `compile_commands.json` file does not correspond to the source folder (but, for example, to a build folder somewhere else on the disk), libclang will fail to load the relative headers and syntax highlighting will not be available for some parts of the source file.