### PR TITLE
Automatically search for compile arguments defined for a source file with a matching name…

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ For convenience, you can also set the
 put the `.clang` file or the compilation database. It overrides the
 default search directory.
 
+If preferred, you can set the `g:chromatica#search_source_args` option to
+have Chromatica the compilation database for similar filenames, if an entry
+for the current file is not found. (This is especially useful if your
+compilation database does not contain entries for header files). Currently,
+this just searches the database for the current file's base name, with the extensions
+.c, .cc, .cpp, or .cxx.
+
 ## Highlight Feature Level
 
 Chromatica provides different feature levels. Each level enables a

--- a/autoload/chromatica/init.vim
+++ b/autoload/chromatica/init.vim
@@ -128,6 +128,8 @@ function! chromatica#init#_variables() abort
                 \ 'g:chromatica#highlight_feature_level', 1)
     call chromatica#util#set_default(
                 \ 'g:chromatica#dotclangfile_search_path', '')
+    call chromatica#util#set_default(
+                \ 'g:chromatica#search_source_args', 0)
 endfunction
 
 function! chromatica#init#_context() abort

--- a/rplugin/python3/chromatica/chromatica.py
+++ b/rplugin/python3/chromatica/chromatica.py
@@ -49,6 +49,8 @@ class Chromatica(logger.LoggingMixin):
         self.highlight_feature_level = self.__vim.vars["chromatica#highlight_feature_level"]
         syntax.HIGHLIGHT_FEATURE_LEVEL = self.highlight_feature_level
 
+        self.search_source_args = self.__vim.vars["chromatica#search_source_args"]
+
         if not cindex.Config.loaded:
             if os.path.isdir(os.path.abspath(self.library_path)):
                 cindex.Config.set_library_path(self.library_path)
@@ -90,6 +92,8 @@ class Chromatica(logger.LoggingMixin):
                 % self.__vim.vars["chromatica#enable_log"])
         self.info("g:chromatica#use_pch=%s" \
                 % self.__vim.vars["chromatica#use_pch"])
+        self.info("g:chromatica#search_source_args=%d" \
+                % self.__vim.vars["chromatica#search_source_args"])
         self.info("-------------------------------------")
         clang_verbose_info = util.get_clang_include_path(self.library_path).decode()
         for line in clang_verbose_info.split("\n"):
@@ -106,7 +110,7 @@ class Chromatica(logger.LoggingMixin):
         filetype = buffer.options["filetype"]
         if not Chromatica.is_supported_filetype(filetype): return False
 
-        args = self.args_db.get_args_filename_ft(filename, filetype)
+        args = self.args_db.get_args_filename_ft(filename, filetype, self.search_source_args)
         self.debug("filename: %s" % filename)
         self.debug("args: %s" % " ".join(args))
 
@@ -279,7 +283,8 @@ class Chromatica(logger.LoggingMixin):
         util.echo(self.__vim, "Compilation Database: %s" % self.args_db.cdb_file)
         util.echo(self.__vim, "Compile Flags: %s" % " ".join( \
                 self.args_db.get_args_filename_ft(context["filename"], \
-                self.__vim.current.buffer.options["filetype"])))
+                self.__vim.current.buffer.options["filetype"], \
+                self.search_source_args)))
         util.echo(self.__vim, ".clang File Search Path: %s" % self.clangfile_search_path)
         if "error" in self.ctx[filename]:
             util.echo(self.__vim, "Error Message: %s" % self.ctx[filename]["error"])

--- a/rplugin/python3/chromatica/compile_args_database.py
+++ b/rplugin/python3/chromatica/compile_args_database.py
@@ -12,6 +12,8 @@ log = logger.logging.getLogger("chromatica.compile_args")
 DEFAULT_STD={"c"   : ["-std=c11"], \
              "cpp" : ["-std=c++14"]}
 
+SOURCE_EXTS=[".c", ".cc", ".cpp", ".cxx"]
+
 def set_default_std(stds):
     DEFAULT_STD = stds
     return True
@@ -126,19 +128,26 @@ class CompileArgsDatabase(object):
             print("Cannot find compile flags for %s in compilation database" % filename)
         return res
 
-    def get_args_filename(self, filename):
+    def get_args_filename(self, filename, search_source_args=False):
         ret = None
         if self.cdb != None:
             ret = self.__get_cdb_args(filename)
+
+        if not ret and search_source_args:
+            filename_base = os.path.splitext(filename)[0]
+            for source_ext in SOURCE_EXTS:
+                ret = self.__get_cdb_args(filename_base + source_ext)
+                if ret:
+                    break
 
         if ret:
             return self.compile_args + ret
         else:
             return self.compile_args
 
-    def get_args_filename_ft(self, filename, filetype):
+    def get_args_filename_ft(self, filename, filetype, search_source_args=False):
         if self.cdb != None or filetype not in DEFAULT_STD:
-            return self.get_args_filename(filename)
+            return self.get_args_filename(filename, search_source_args)
 
         ret = DEFAULT_STD[filetype]
         return ret + self.compile_args


### PR DESCRIPTION
…if configured to do so. (Also update README.md to document this.)

Resolves #59 and (I believe) #40.
Header highlighting would fail if compile arguments for the header file were omitted from compile_commands.json. This resolves the issue by simply searching for a matching source file in the database.