### PR TITLE
Support compile_flags.txt

### DIFF
--- a/rplugin/python3/chromatica/compile_args_database.py
+++ b/rplugin/python3/chromatica/compile_args_database.py
@@ -45,6 +45,9 @@ class CompileArgsDatabase(object):
             self.__clang_file = os.path.join(clang_file_path, ".clang")
             if os.path.exists(self.__clang_file):
                 return
+            self.__clang_file = os.path.join(clang_file_path, "compile_flags.txt")
+            if os.path.exists(self.__clang_file):
+                return
             clang_file_path = os.path.dirname(clang_file_path)
 
         self.__clang_file = None


### PR DESCRIPTION
`compile_flags.txt` is also a file indicating flags to clang, having the same function as `.clang`. It's used by `clangd` so supporting it would be better.