### PR TITLE
FIX: Fix arg[0] IndexError in compile_args_database.py

### DIFF
--- a/rplugin/python3/chromatica/compile_args_database.py
+++ b/rplugin/python3/chromatica/compile_args_database.py
@@ -168,7 +168,7 @@ class CompileArgsDatabase(object):
                 cwd = cmds.directory
                 skip = 0
                 for arg in cmds.arguments:
-                    if skip and arg[0] != "-":
+                    if skip and (len(arg) == 0 or arg[0] != "-"):
                         skip = 0
                         continue
                     if arg == "-o" or arg == "-c":


### PR DESCRIPTION
Hi, I have noticed a issue with my chromatica version, leading to the following error.

```
error caught in async handler 'chromatica_parse [{'bufnr': 1, 'filename': '', 'changedtick': 2, 'position': [1, 1], 'highlight_tick': 1, 'range': [1, 1], 'rpc': 'chromatica_parse'}]'
Traceback (most recent call last):                                                                                                                                                                       
  File "/<snip>/chromatica.nvim/rplugin/python3/chromatica/__init__.py", line 47, in parse                                                                                    
    self.__chromatica.parse(context)                                                                                                                                                                     
  File "/<snip>/chromatica.nvim/rplugin/python3/chromatica/chromatica.py", line 131, in parse                                                                                 
    if not self._init_context(context): return ret                                                                                                                                                       
  File "/<snip>/rplugin/python3/chromatica/chromatica.py", line 115, in _init_context                                                                         
    args = self.args_db.get_args_filename_ft(filename, filetype)                                                                                                                                         
  File "/<snip>/chromatica.nvim/rplugin/python3/chromatica/compile_args_database.py", line 218, in get_args_filename_ft                                                      
    ret = self.get_args_filename(filename, search_source_args)                                                                                                                                           
  File "/<snip>/chromatica.nvim/rplugin/python3/chromatica/compile_args_database.py", line 206, in get_args_filename                                                         
    cdb_ret = self.get_cdb_args(filename)                                                                                                                                                                
  File "/<snip>/chromatica.nvim/rplugin/python3/chromatica/compile_args_database.py", line 171, in get_cdb_args                                                              
    if skip and arg[0] != "-":                                                                                                                                                                           
       IndexError: string index out of range
```

I have looked into it and it appears that the ``arg[0]`` on line 171 compile_args_database.py  
can be called with an empty string. Al though this can be because of wrong configuration on my end 
(I have been unable to pinpoint the source of the empty ``arg[0]`` myself) a small alteration to the if prevents the error.

This pull request fixes the error.  